### PR TITLE
Introduce seed key for EGS52

### DIFF
--- a/UnlockECU/UnlockECU/Security/VGSSecurityAlgo2Bytes.cs
+++ b/UnlockECU/UnlockECU/Security/VGSSecurityAlgo2Bytes.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace UnlockECU
+{
+    /// <summary>
+    /// Implementation of VGSSecurityAlgo for 2 bytes seed/key pairs
+    /// </summary>
+    class VGSSecurityAlgo2Bytes : SecurityProvider
+    {
+        public override bool GenerateKey(byte[] inSeed, byte[] outKey, int accessLevel, List<Parameter> parameters)
+        {
+            byte[] cryptoKeyBytes = GetParameterBytearray(parameters, "K");
+            uint cryptoKey = cryptoKeyBytes[1] | ((uint)cryptoKeyBytes[0]) << 8;
+            if ((inSeed.Length != 2) || (outKey.Length != 2))
+            {
+                return false;
+            }
+
+            uint seed = inSeed[0] | ((uint)inSeed[1]) << 8;
+            uint seedKey = cryptoKey * (cryptoKey ^ seed);
+
+            outKey[0] = (byte)(seedKey >> 8);
+            outKey[1] = (byte)seedKey;
+            return true;
+        }
+        public override string GetProviderName()
+        {
+            return "VGSSecurityAlgo2Bytes";
+        }
+    }
+}

--- a/UnlockECU/UnlockECU/Security/VGSSecurityAlgoExt.cs
+++ b/UnlockECU/UnlockECU/Security/VGSSecurityAlgoExt.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace UnlockECU
+{
+    /// <summary>
+    /// Implementation of extended VGS Algo with different keys for multiplication and xor
+    /// </summary>
+    class VGSSecurityAlgoExt : SecurityProvider
+    {
+        public override bool GenerateKey(byte[] inSeed, byte[] outKey, int accessLevel, List<Parameter> parameters)
+        {
+            byte[] cryptoKeyMultBytes = GetParameterBytearray(parameters, "M");
+            uint cryptoKeyMult = BytesToInt(cryptoKeyMultBytes, Endian.Big);
+
+            byte[] cryptoKeyXorBytes = GetParameterBytearray(parameters, "X");
+            uint cryptoKeyXor = BytesToInt(cryptoKeyXorBytes, Endian.Big);
+
+            if ((inSeed.Length != 4) || (outKey.Length != 4))
+            {
+                return false;
+            }
+
+            long seed = BytesToInt(inSeed, Endian.Big);
+            long seedKey = cryptoKeyMult * (cryptoKeyXor ^ seed);
+
+            IntToBytes((uint)seedKey, outKey, Endian.Big);
+            return true;
+        }
+        public override string GetProviderName()
+        {
+            return "VGSSecurityAlgoExt";
+        }
+    }
+}

--- a/UnlockECU/db.json
+++ b/UnlockECU/db.json
@@ -11788,6 +11788,38 @@
     ]
   },
   {
+    "EcuName": "EGS52",
+    "Aliases": [],
+    "AccessLevel": 5,
+    "SeedLength": 4,
+    "KeyLength": 4,
+    "Provider": "VGSSecurityAlgo",
+    "Origin": "EGS52_27_05@VladLupashevskyi-@rnd-ash",
+    "Parameters": [
+      {
+        "Key": "K",
+        "Value": "5AA5A5A5",
+        "DataType": "ByteArray"
+      }
+    ]
+  },
+  {
+    "EcuName": "EGS52",
+    "Aliases": [],
+    "AccessLevel": 1,
+    "SeedLength": 2,
+    "KeyLength": 2,
+    "Provider": "VGSSecurityAlgo2Bytes",
+    "Origin": "EGS52_27_01_27_02@VladLupashevskyi-@rnd-ash",
+    "Parameters": [
+      {
+        "Key": "K",
+        "Value": "5AA5",
+        "DataType": "ByteArray"
+      }
+    ]
+  },
+  {
     "EcuName": "Subaru_2EE2",
     "Aliases": [],
     "AccessLevel": 3,

--- a/UnlockECU/db.json
+++ b/UnlockECU/db.json
@@ -11819,6 +11819,27 @@
       }
     ]
   },
+    {
+    "EcuName": "EGS53",
+    "Aliases": [],
+    "AccessLevel": 1,
+    "SeedLength": 4,
+    "KeyLength": 4,
+    "Provider": "VGSSecurityAlgoExt",
+    "Origin": "EGS53_27_05@VladLupashevskyi-@rnd-ash",
+    "Parameters": [
+      {
+        "Key": "X",
+        "Value": "6BB6B6B6",
+        "DataType": "ByteArray"
+      },
+	  {
+        "Key": "M",
+        "Value": "49949494",
+        "DataType": "ByteArray"
+      }
+    ]
+  },
   {
     "EcuName": "Subaru_2EE2",
     "Aliases": [],


### PR DESCRIPTION
Here is the implementation of seed key for EGS52 controller.

Me and @rnd-ash discovered that there are hardcoded seed and key for each software of EGS52.

We gathered some pairs and then I used your C32NativeExtension dll to analyse PAL script for flashing.

27 05 wasnt tested on real ECU, it was just taken from PAL script by patching a different boot loader flag.